### PR TITLE
Sanitize mount logs

### DIFF
--- a/src/wasmtime_unit.rs
+++ b/src/wasmtime_unit.rs
@@ -149,12 +149,12 @@ impl Wasmtime {
         let mut preopen_dirs = Vec::new();
 
         for DirectoryMount { guest, host } in dirs.iter() {
-            info!("Mounting: {}::{}", host.display(), guest.display());
+            info!("Mounting: {}", guest.display());
 
             preopen_dirs.push((
                 guest.as_os_str().to_str().unwrap().to_string(),
                 preopen_dir(host)
-                    .with_context(|| format!("Failed to open directory '{}'", host.display()))?,
+                    .with_context(|| format!("Failed to mount '{}'", guest.display()))?,
             ));
         }
 


### PR DESCRIPTION
Remove the mistakenly ommited host paths from logs related to directory mounting

Part of https://github.com/golemfactory/yagna/issues/229