### PR TITLE
Fix deploy output printing

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-runtime-wasi"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -20,6 +20,7 @@ wasmtime-wasi = "0.18"
 wasi-common = "0.18"
 libc = "0.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+ya-runtime-api = { version = "0.1", git = "https://github.com/golemfactory/yagna.git", features=["codec"] }
 zip="0.5"
 
 [dev-dependencies]

--- a/crates/api/src/deploy.rs
+++ b/crates/api/src/deploy.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use ya_runtime_api::deploy;
 
 /// Represents deployed Yagna Wasm image with set up volumes inside the
 /// container.
@@ -35,7 +36,7 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize)]
 pub struct DeployFile {
     image_path: PathBuf,
-    vols: Vec<ContainerVolume>,
+    vols: Vec<deploy::ContainerVolume>,
 }
 
 impl DeployFile {
@@ -45,7 +46,7 @@ impl DeployFile {
             .manifest
             .mount_points
             .iter()
-            .map(|mount_point| ContainerVolume {
+            .map(|mount_point| deploy::ContainerVolume {
                 name: format!("vol-{}", Uuid::new_v4()),
                 path: absolute_path(mount_point.path()).into(),
             })
@@ -89,7 +90,7 @@ impl DeployFile {
     }
 
     /// Returns an iterator over mapped container volumes.
-    pub fn vols(&self) -> impl Iterator<Item = &ContainerVolume> {
+    pub fn vols(&self) -> impl Iterator<Item = &deploy::ContainerVolume> {
         self.vols.iter()
     }
 }
@@ -104,17 +105,6 @@ fn absolute_path(path: &str) -> Cow<'_, str> {
     } else {
         Cow::Owned(format!("/{}", path))
     }
-}
-
-/// Represents name and path to the mapped volume in the container.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct ContainerVolume {
-    /// Volume name
-    pub name: String,
-
-    /// Path to the volume inside the container
-    pub path: String,
 }
 
 /// Deploys the Wasm image into the workspace.
@@ -139,8 +129,13 @@ pub fn deploy(workdir: impl AsRef<Path>, path: impl AsRef<Path>) -> Result<()> {
     deploy_file.save(workdir)?;
     deploy_file.create_dirs(workdir)?;
 
-    log::info!("Deploy completed");
-    log::info!("Volumes = {:#?}", deploy_file.vols);
+    let res = deploy::DeployResult {
+        valid: Ok(Default::default()),
+        vols: deploy_file.vols,
+        start_mode: Default::default(),
+    };
+
+    println!("{}\n", serde_json::to_string(&res)?);
 
     Ok(())
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -67,5 +67,5 @@ mod entrypoint;
 mod manifest;
 mod wasmtime_unit;
 
-pub use deploy::{deploy, ContainerVolume, DeployFile};
+pub use deploy::{deploy, DeployFile};
 pub use entrypoint::{run, start};


### PR DESCRIPTION
Deploy output was not correctly formatted and printed to stderr. This additionally removes some redundant structs uses `ya-runtime-api` instead.